### PR TITLE
feat(menu) : 메뉴생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/easy/gc_coffee_api/controller/MenuController.java
+++ b/src/main/java/easy/gc_coffee_api/controller/MenuController.java
@@ -1,0 +1,35 @@
+package easy.gc_coffee_api.controller;
+
+import easy.gc_coffee_api.dto.CreateMenuRequestDto;
+import easy.gc_coffee_api.dto.CreateMenuResponseDto;
+import easy.gc_coffee_api.exception.GCException;
+import easy.gc_coffee_api.exception.ThumnailCreateException;
+import easy.gc_coffee_api.usecase.menu.CreateMenuUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MenuController {
+
+    private final CreateMenuUsecase createMenuUsecase;
+
+    @PostMapping("/menus")
+    public ResponseEntity<CreateMenuResponseDto> create(@RequestBody @Validated CreateMenuRequestDto requestDto) {
+        try {
+            Long id = createMenuUsecase.excute(
+                    requestDto.getMenuName(),
+                    requestDto.getCategory(),
+                    requestDto.getPrice(),
+                    requestDto.getThumnailId()
+            );
+            return ResponseEntity.ok(new CreateMenuResponseDto(id));
+        } catch (ThumnailCreateException thumnailCreateException) {
+            throw new GCException(thumnailCreateException.getMessage(), thumnailCreateException, 400);
+        }
+    }
+}

--- a/src/main/java/easy/gc_coffee_api/controller/MenuController.java
+++ b/src/main/java/easy/gc_coffee_api/controller/MenuController.java
@@ -22,7 +22,7 @@ public class MenuController {
     @PostMapping("/menus")
     public ResponseEntity<CreateMenuResponseDto> create(@RequestBody @Validated CreateMenuRequestDto requestDto) {
         try {
-            Long id = createMenuUsecase.excute(
+            Long id = createMenuUsecase.execute(
                     requestDto.getMenuName(),
                     requestDto.getCategory(),
                     requestDto.getPrice(),

--- a/src/main/java/easy/gc_coffee_api/controller/MenuController.java
+++ b/src/main/java/easy/gc_coffee_api/controller/MenuController.java
@@ -5,6 +5,7 @@ import easy.gc_coffee_api.dto.CreateMenuResponseDto;
 import easy.gc_coffee_api.exception.GCException;
 import easy.gc_coffee_api.exception.ThumnailCreateException;
 import easy.gc_coffee_api.usecase.menu.CreateMenuUsecase;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -28,8 +29,8 @@ public class MenuController {
                     requestDto.getThumnailId()
             );
             return ResponseEntity.ok(new CreateMenuResponseDto(id));
-        } catch (ThumnailCreateException thumnailCreateException) {
-            throw new GCException(thumnailCreateException.getMessage(), thumnailCreateException, 400);
+        } catch (ThumnailCreateException | EntityNotFoundException e ) {
+            throw new GCException(e.getMessage(), e, 400);
         }
     }
 }

--- a/src/main/java/easy/gc_coffee_api/dto/CreateMenuRequestDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/CreateMenuRequestDto.java
@@ -1,0 +1,24 @@
+package easy.gc_coffee_api.dto;
+
+import easy.gc_coffee_api.entity.common.Category;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CreateMenuRequestDto {
+
+    @NotBlank(message = "menuName은 string이여야 합니다")
+    private String menuName;
+    @NotBlank
+    private String category;
+    @NotNull
+    @Min(0)
+    private Integer price;
+    private Long thumnailId;
+
+    public Category getCategory() {
+        return Category.findByName(category);
+    }
+}

--- a/src/main/java/easy/gc_coffee_api/dto/CreateMenuRequestDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/CreateMenuRequestDto.java
@@ -9,12 +9,12 @@ import lombok.Data;
 @Data
 public class CreateMenuRequestDto {
 
-    @NotBlank(message = "menuName은 string이여야 합니다")
+    @NotBlank(message = "menuName은 빈값이 아니여야합니다")
     private String menuName;
-    @NotBlank
+    @NotBlank(message = "category는 빈값이 아니여야합니다.")
     private String category;
-    @NotNull
-    @Min(0)
+    @NotNull(message = "price는 필 수 입니다.")
+    @Min(value = 0,message = "가격은 0이상이여야 합니다.")
     private Integer price;
     private Long thumnailId;
 

--- a/src/main/java/easy/gc_coffee_api/dto/CreateMenuRequestDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/CreateMenuRequestDto.java
@@ -1,6 +1,7 @@
 package easy.gc_coffee_api.dto;
 
 import easy.gc_coffee_api.entity.common.Category;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,7 +19,7 @@ public class CreateMenuRequestDto {
     private Integer price;
     private Long thumnailId;
 
-    public Category getCategory() {
+    public Category getCategory() throws EntityNotFoundException {
         return Category.findByName(category);
     }
 }

--- a/src/main/java/easy/gc_coffee_api/dto/CreateMenuResponseDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/CreateMenuResponseDto.java
@@ -1,0 +1,10 @@
+package easy.gc_coffee_api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class CreateMenuResponseDto {
+    private Long id;
+}

--- a/src/main/java/easy/gc_coffee_api/entity/Thumnail.java
+++ b/src/main/java/easy/gc_coffee_api/entity/Thumnail.java
@@ -2,23 +2,30 @@ package easy.gc_coffee_api.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode
 public class Thumnail {
-    @ManyToOne
-    @JoinColumn(name = "file_id")
-    private File thumbnail;
-//
-//    @Column(name = "file_id")
-//    private Long file_id;
+//    @ManyToOne
+//    @JoinColumn(name = "file_id")
+//    private File thumbnail;
 
+    @Column(name = "file_id")
+    private Long fileId;
+
+    public Thumnail(Long fileId,String type) throws IllegalArgumentException {
+        validateType(type);
+        this.fileId = fileId;
+    }
+
+    private void validateType(String type) throws IllegalArgumentException {
+        String[] split = type.split("/");
+        if(split.length < 1 || !split[0].equalsIgnoreCase("image")){
+            throw new IllegalArgumentException("Invalid type");
+        }
+    }
 }

--- a/src/main/java/easy/gc_coffee_api/entity/common/Category.java
+++ b/src/main/java/easy/gc_coffee_api/entity/common/Category.java
@@ -1,5 +1,19 @@
 package easy.gc_coffee_api.entity.common;
 
+import java.util.Arrays;
+
 public enum Category {
-    COFFEE_BEAN
+    COFFEE_BEAN;
+
+    public static Category findByName(String name) {
+        return Arrays.stream(values())
+                .filter(category->sameName(category.name(), name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean sameName(String categoryName,String name) {
+        String replace = categoryName.replace("_", "");
+        return replace.equalsIgnoreCase(name) || categoryName.equalsIgnoreCase(name);
+    }
 }

--- a/src/main/java/easy/gc_coffee_api/entity/common/Category.java
+++ b/src/main/java/easy/gc_coffee_api/entity/common/Category.java
@@ -1,5 +1,7 @@
 package easy.gc_coffee_api.entity.common;
 
+import jakarta.persistence.EntityNotFoundException;
+
 import java.util.Arrays;
 
 public enum Category {
@@ -9,7 +11,7 @@ public enum Category {
         return Arrays.stream(values())
                 .filter(category->sameName(category.name(), name))
                 .findFirst()
-                .orElse(null);
+                .orElseThrow(()->new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
     }
 
     private static boolean sameName(String categoryName,String name) {

--- a/src/main/java/easy/gc_coffee_api/exception/GCException.java
+++ b/src/main/java/easy/gc_coffee_api/exception/GCException.java
@@ -5,13 +5,15 @@ import lombok.Getter;
 public class GCException extends RuntimeException {
 
     @Getter
-    private Integer code;
+    private final Integer code;
 
-    public GCException(String message) {
+    public GCException(String message,Integer code) {
         super(message);
+        this.code = code;
     }
 
-    public GCException(String message, Throwable cause) {
+    public GCException(String message, Throwable cause,Integer code) {
         super(message, cause);
+        this.code = code;
     }
 }

--- a/src/main/java/easy/gc_coffee_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/easy/gc_coffee_api/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package easy.gc_coffee_api.exception;
 import easy.gc_coffee_api.dto.ErrorResponseDto;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,5 +16,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDto> handleException(GCException exception) {
         Integer code = exception.getCode();
         return new ResponseEntity<>(new ErrorResponseDto(exception.getMessage(), code), HttpStatusCode.valueOf(code));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleException(MethodArgumentNotValidException exception) {
+        ObjectError firstError = exception.getBindingResult().getAllErrors().getFirst();
+        return new ResponseEntity<>(new ErrorResponseDto(firstError.getDefaultMessage(), 400), HttpStatusCode.valueOf(400));
     }
 }

--- a/src/main/java/easy/gc_coffee_api/exception/ThumnailCreateException.java
+++ b/src/main/java/easy/gc_coffee_api/exception/ThumnailCreateException.java
@@ -1,0 +1,11 @@
+package easy.gc_coffee_api.exception;
+
+public class ThumnailCreateException extends RuntimeException{
+    public ThumnailCreateException(String message) {
+        super(message);
+    }
+
+    public ThumnailCreateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecase.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecase.java
@@ -16,7 +16,7 @@ public class CreateMenuUsecase{
     private final ThumnailFatory thumnailFatory;
 
     @Transactional
-    public Long excute(String menuName, Category category, int price, Long fileId) throws ThumnailCreateException {
+    public Long execute(String menuName, Category category, int price, Long fileId) throws ThumnailCreateException {
         Thumnail thumnail = thumnailFatory.create(fileId);
         Menu menu = menuSaver.save(menuName, category, price, thumnail);
         return menu.getId();

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecase.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecase.java
@@ -3,19 +3,22 @@ package easy.gc_coffee_api.usecase.menu;
 import easy.gc_coffee_api.entity.Menu;
 import easy.gc_coffee_api.entity.Thumnail;
 import easy.gc_coffee_api.entity.common.Category;
-import easy.gc_coffee_api.repository.MenuRepository;
+import easy.gc_coffee_api.exception.ThumnailCreateException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
 @RequiredArgsConstructor
 public class CreateMenuUsecase{
 
-    private final MenuRepository menuRepository;
+    private final MenuSaver menuSaver;
     private final ThumnailFatory thumnailFatory;
 
-    public Long process(String menuName, Category category, int price, Long fileId) {
+    @Transactional
+    public Long excute(String menuName, Category category, int price, Long fileId) throws ThumnailCreateException {
         Thumnail thumnail = thumnailFatory.create(fileId);
-        Menu menu = menuRepository.save( new Menu(menuName, price, category, null));
+        Menu menu = menuSaver.save(menuName, category, price, thumnail);
         return menu.getId();
     }
-
 }

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/MenuSaver.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/MenuSaver.java
@@ -1,0 +1,19 @@
+package easy.gc_coffee_api.usecase.menu;
+
+import easy.gc_coffee_api.entity.Menu;
+import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.common.Category;
+import easy.gc_coffee_api.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MenuSaver {
+
+    private final MenuRepository menuRepository;
+
+    public Menu save(String menuName, Category category, int price, Thumnail thumnail) {
+        return menuRepository.save(new Menu(menuName, price, category, thumnail));
+    }
+}

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/ThumnailFatory.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/ThumnailFatory.java
@@ -1,16 +1,32 @@
 package easy.gc_coffee_api.usecase.menu;
 
+import easy.gc_coffee_api.entity.File;
 import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.exception.ThumnailCreateException;
+import easy.gc_coffee_api.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class ThumnailFatory {
 
     private static final Long DEFAULT_THUMNAIL_ID = 1L;
+    private final FileRepository fileRepository;
 
     public Thumnail create(Long thumnailId) {
-//        if(thumnailId == null) {
-//            return new Thumnail(DEFAULT_THUMNAIL_ID);
-//        }
-//        return new Thumnail(thumnailId);
-        return null;
+        try {
+            File file = getFile(thumnailId);
+            return new Thumnail(file.getId(),file.getMimetype());
+        }catch (IllegalArgumentException e){
+            throw new ThumnailCreateException("image type이 아닙니다.");
+        }
+    }
+
+    private File getFile(Long thumnailId) throws ThumnailCreateException {
+        if(thumnailId == null) {
+            return fileRepository.findById(DEFAULT_THUMNAIL_ID).get();
+        }
+        return fileRepository.findById(thumnailId).orElseThrow(()->new ThumnailCreateException(String.format("thumnail id로 파일을 찾을 수 없습니다.")));
     }
 }

--- a/src/test/java/easy/gc_coffee_api/entity/ThumnailTest.java
+++ b/src/test/java/easy/gc_coffee_api/entity/ThumnailTest.java
@@ -1,0 +1,19 @@
+package easy.gc_coffee_api.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ThumnailTest {
+
+    @Test
+    void 이미지_타입아닐시_예외(){
+        assertThatThrownBy(() -> new Thumnail(1L,"text/html")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 이미지_정상_생성(){
+        assertDoesNotThrow(() -> new Thumnail(1L,"image/png"));
+    }
+}

--- a/src/test/java/easy/gc_coffee_api/entity/common/CategoryTest.java
+++ b/src/test/java/easy/gc_coffee_api/entity/common/CategoryTest.java
@@ -1,0 +1,16 @@
+package easy.gc_coffee_api.entity.common;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CategoryTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"COFFEE_BEAN","coffee_bean","coffeeBean","coffeebean"})
+    void 카테고리검색(String category) {
+        Category coffeeBean = Category.findByName(category);
+        assertThat(coffeeBean).isEqualTo(Category.COFFEE_BEAN);
+    }
+}

--- a/src/test/java/easy/gc_coffee_api/entity/common/CategoryTest.java
+++ b/src/test/java/easy/gc_coffee_api/entity/common/CategoryTest.java
@@ -1,9 +1,11 @@
 package easy.gc_coffee_api.entity.common;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CategoryTest {
 
@@ -12,5 +14,11 @@ class CategoryTest {
     void 카테고리검색(String category) {
         Category coffeeBean = Category.findByName(category);
         assertThat(coffeeBean).isEqualTo(Category.COFFEE_BEAN);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"COFFE_BEAN","coffe_bean","coffeBean","coffeebea"})
+    void 카테고리검색_실패(String category) {
+        assertThatThrownBy(() -> Category.findByName(category)).isInstanceOf(EntityNotFoundException.class);
     }
 }

--- a/src/test/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecaseTest.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecaseTest.java
@@ -40,7 +40,7 @@ public class CreateMenuUsecaseTest {
         when(thumnailFatory.create(eq(fileId))).thenReturn(thumnail);
         when(menuSaver.save(eq(menuName),eq(category),eq(price),eq(thumnail))).thenReturn(new Menu(entityId, menuName, price, category,thumnail));
 
-        Long id = createMenuUsecase.excute(menuName, category, price, fileId);
+        Long id = createMenuUsecase.execute(menuName, category, price, fileId);
 
         assertThat(id).isEqualTo(entityId);
     }

--- a/src/test/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecaseTest.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecaseTest.java
@@ -3,7 +3,6 @@ package easy.gc_coffee_api.usecase.menu;
 import easy.gc_coffee_api.entity.Menu;
 import easy.gc_coffee_api.entity.Thumnail;
 import easy.gc_coffee_api.entity.common.Category;
-import easy.gc_coffee_api.repository.MenuRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -19,7 +17,7 @@ import static org.mockito.Mockito.when;
 public class CreateMenuUsecaseTest {
 
     @Mock
-    private MenuRepository menuRepository;
+    private MenuSaver menuSaver;
     @Mock
     private ThumnailFatory thumnailFatory;
 
@@ -27,7 +25,7 @@ public class CreateMenuUsecaseTest {
 
     @BeforeEach
     void setUp() {
-        createMenuUsecase =  new CreateMenuUsecase(menuRepository, thumnailFatory);
+        createMenuUsecase =  new CreateMenuUsecase(menuSaver, thumnailFatory);
     }
 
     @Test
@@ -37,10 +35,12 @@ public class CreateMenuUsecaseTest {
         int price = 1000;
         Long entityId = 1L;
         Long fileId = 2L;
-//        when(thumnailFatory.create(eq(fileId))).thenReturn(new Thumnail(1L));
-        when(menuRepository.save(any())).thenReturn(new Menu(entityId, menuName, price, category, new Thumnail(null)));
 
-        Long id = createMenuUsecase.process(menuName, category, price, fileId);
+        Thumnail thumnail = new Thumnail(2L, "image/jpeg");
+        when(thumnailFatory.create(eq(fileId))).thenReturn(thumnail);
+        when(menuSaver.save(eq(menuName),eq(category),eq(price),eq(thumnail))).thenReturn(new Menu(entityId, menuName, price, category,thumnail));
+
+        Long id = createMenuUsecase.excute(menuName, category, price, fileId);
 
         assertThat(id).isEqualTo(entityId);
     }

--- a/src/test/java/easy/gc_coffee_api/usecase/menu/ThumnailFatoryTest.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/menu/ThumnailFatoryTest.java
@@ -15,5 +15,6 @@ class ThumnailFatoryTest {
 
     @Test
     void null입력시_기본이미지_생성(){
+        //TODO 테스트 작성
     }
 }

--- a/src/test/java/easy/gc_coffee_api/usecase/menu/ThumnailFatoryTest.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/menu/ThumnailFatoryTest.java
@@ -1,0 +1,19 @@
+package easy.gc_coffee_api.usecase.menu;
+
+import easy.gc_coffee_api.repository.FileRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+class ThumnailFatoryTest {
+
+    @Mock
+    private FileRepository fileRepository;
+
+    @Test
+    void null입력시_기본이미지_생성(){
+    }
+}


### PR DESCRIPTION
### PR 타입 (하나 이상 체크)
- [x] Feat : 새로운 기능 추가
- [ ] Bug : 버그 발견
- [ ] Fix : 기능 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락 등
- [ ] Refactor : 리팩토링

### PR 요약
커피 메뉴 생성 api 구현

### 반영 브랜치
예) feature/create_coffee_menu -> dev

### 주요 변경 사항
- `MenuController`: POST /menus 추가
- `CreateMenuUsecase`: 메뉴 생성 로직 구현
- `CreateMenuRequestDto`: 유효성 검사 추가
- `CreateMenuResponseDto` : id 반환기능 추가
-  `ThumnailCreateException` : 섬네일 생성 예외
-  `GCException` : 코드 저장 기능 추가
-  `GlobalExceptionHandler` : validation 핸들링 기능 구현
-  `MenuSaver` : 메뉴 생성 기능
-  `ThumnailFatory` : 섬네일 생성 기능 추가

### 테스트 여부
- CreateMenuUsecase 테스트 작성
- MenuController 통합 테스트 진행