### PR TITLE
feat(menu): 커피 메뉴 조회 기능 구현

### DIFF
--- a/src/main/java/easy/gc_coffee_api/controller/MenuController.java
+++ b/src/main/java/easy/gc_coffee_api/controller/MenuController.java
@@ -2,11 +2,14 @@ package easy.gc_coffee_api.controller;
 
 import easy.gc_coffee_api.dto.CreateMenuRequestDto;
 import easy.gc_coffee_api.dto.CreateMenuResponseDto;
+import easy.gc_coffee_api.dto.MenusResponseDto;
 import easy.gc_coffee_api.exception.GCException;
 import easy.gc_coffee_api.exception.ThumnailCreateException;
 import easy.gc_coffee_api.usecase.menu.CreateMenuUsecase;
 import jakarta.persistence.EntityNotFoundException;
+import easy.gc_coffee_api.usecase.menu.GetMenusUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MenuController {
 
     private final CreateMenuUsecase createMenuUsecase;
+    private final GetMenusUseCase getMenusUseCase;
 
     @PostMapping("/menus")
     public ResponseEntity<CreateMenuResponseDto> create(@RequestBody @Validated CreateMenuRequestDto requestDto) {
@@ -33,5 +37,12 @@ public class MenuController {
         } catch (ThumnailCreateException | EntityNotFoundException e ) {
             throw new GCException(e.getMessage(), e, 400);
         }
+    }
+
+
+    @GetMapping("/menus")
+    public ResponseEntity<MenusResponseDto> getMenus() {
+        MenusResponseDto responseDto = getMenusUseCase.getMenus();
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/easy/gc_coffee_api/controller/MenuController.java
+++ b/src/main/java/easy/gc_coffee_api/controller/MenuController.java
@@ -9,6 +9,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/easy/gc_coffee_api/dto/MenuResponseDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/MenuResponseDto.java
@@ -1,0 +1,22 @@
+package easy.gc_coffee_api.dto;
+
+import easy.gc_coffee_api.entity.common.Category;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MenuResponseDto {
+    private String name;
+    private int price;
+    private Category category;
+
+    @Builder
+    public MenuResponseDto(String name, int price, Category category) {
+        this.name = name;
+        this.price = price;
+        this.category = category;
+    }
+}

--- a/src/main/java/easy/gc_coffee_api/dto/MenuResponseDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/MenuResponseDto.java
@@ -1,5 +1,6 @@
 package easy.gc_coffee_api.dto;
 
+import easy.gc_coffee_api.entity.Thumnail;
 import easy.gc_coffee_api.entity.common.Category;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,11 +13,13 @@ public class MenuResponseDto {
     private String name;
     private int price;
     private Category category;
+    private Thumnail thumnail;
 
     @Builder
-    public MenuResponseDto(String name, int price, Category category) {
+    public MenuResponseDto(String name, int price, Category category, Thumnail thumnail) {
         this.name = name;
         this.price = price;
         this.category = category;
+        this.thumnail = thumnail;
     }
 }

--- a/src/main/java/easy/gc_coffee_api/dto/MenuResponseDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/MenuResponseDto.java
@@ -12,13 +12,13 @@ public class MenuResponseDto {
     private String name;
     private int price;
     private Category category;
-    private Long thumnail;
+    private String thumbnailUrl;
 
     @Builder
-    public MenuResponseDto(String name, int price, Category category, Long thumnail) {
+    public MenuResponseDto(String name, int price, Category category, String thumbnailUrl) {
         this.name = name;
         this.price = price;
         this.category = category;
-        this.thumnail = thumnail;
+        this.thumbnailUrl = thumbnailUrl;
     }
 }

--- a/src/main/java/easy/gc_coffee_api/dto/MenuResponseDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/MenuResponseDto.java
@@ -1,6 +1,5 @@
 package easy.gc_coffee_api.dto;
 
-import easy.gc_coffee_api.entity.Thumnail;
 import easy.gc_coffee_api.entity.common.Category;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,10 +12,10 @@ public class MenuResponseDto {
     private String name;
     private int price;
     private Category category;
-    private Thumnail thumnail;
+    private Long thumnail;
 
     @Builder
-    public MenuResponseDto(String name, int price, Category category, Thumnail thumnail) {
+    public MenuResponseDto(String name, int price, Category category, Long thumnail) {
         this.name = name;
         this.price = price;
         this.category = category;

--- a/src/main/java/easy/gc_coffee_api/dto/MenusResponseDto.java
+++ b/src/main/java/easy/gc_coffee_api/dto/MenusResponseDto.java
@@ -1,0 +1,19 @@
+package easy.gc_coffee_api.dto;
+
+import easy.gc_coffee_api.entity.common.Category;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MenusResponseDto {
+
+    List<MenuResponseDto> menus = new ArrayList<>();
+
+    public MenusResponseDto (List<MenuResponseDto> menus){
+        this.menus = menus;
+    }
+
+}

--- a/src/main/java/easy/gc_coffee_api/entity/Menu.java
+++ b/src/main/java/easy/gc_coffee_api/entity/Menu.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Menu extends BaseDateEntity {
 

--- a/src/main/java/easy/gc_coffee_api/entity/Thumnail.java
+++ b/src/main/java/easy/gc_coffee_api/entity/Thumnail.java
@@ -5,10 +5,15 @@ import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
 
 @Embeddable
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode
+@Getter
 public class Thumnail {
 //    @ManyToOne
 //    @JoinColumn(name = "file_id")

--- a/src/main/java/easy/gc_coffee_api/repository/MenuRepository.java
+++ b/src/main/java/easy/gc_coffee_api/repository/MenuRepository.java
@@ -1,7 +1,14 @@
 package easy.gc_coffee_api.repository;
 
+import easy.gc_coffee_api.dto.MenuResponseDto;
 import easy.gc_coffee_api.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MenuRepository extends JpaRepository<Menu,Long> {
+
+    @Query("SELECT new easy.gc_coffee_api.dto.MenuResponseDto(m.name, m.price, m.category,case when f is null then null when f is not null then f.url end) FROM Menu m LEFT JOIN File f ON m.thumnail.fileId = f.id")
+    List<MenuResponseDto> findAllByMenuResponseDto();
 }

--- a/src/main/java/easy/gc_coffee_api/service/MenuService.java
+++ b/src/main/java/easy/gc_coffee_api/service/MenuService.java
@@ -1,0 +1,33 @@
+package easy.gc_coffee_api.service;
+
+import easy.gc_coffee_api.dto.MenuResponseDto;
+import easy.gc_coffee_api.entity.Menu;
+import easy.gc_coffee_api.repository.MenuRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+
+    public List<MenuResponseDto> getMenus() {
+        List<MenuResponseDto> menus = new ArrayList<>();
+        List<Menu> all = menuRepository.findAll();
+        for(Menu menu : all){
+            MenuResponseDto menuResponseDto = MenuResponseDto.builder()
+                    .name(menu.getName())
+                    .price(menu.getPrice())
+                    .category(menu.getCategory())
+                    .build();
+            menus.add(menuResponseDto);
+        }
+        return menus;
+    }
+}

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
@@ -1,33 +1,32 @@
-package easy.gc_coffee_api.service;
+package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.dto.MenuResponseDto;
+import easy.gc_coffee_api.dto.MenusResponseDto;
 import easy.gc_coffee_api.entity.Menu;
 import easy.gc_coffee_api.repository.MenuRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
-public class MenuService {
-
+public class GetMenusUseCase {
     private final MenuRepository menuRepository;
 
-    public List<MenuResponseDto> getMenus() {
+    public MenusResponseDto getMenus() {
+        List<Menu> menuList = menuRepository.findAll();
         List<MenuResponseDto> menus = new ArrayList<>();
-        List<Menu> all = menuRepository.findAll();
-        for(Menu menu : all){
-            MenuResponseDto menuResponseDto = MenuResponseDto.builder()
+        for (Menu menu : menuList) {
+            MenuResponseDto dto = MenuResponseDto.builder()
                     .name(menu.getName())
                     .price(menu.getPrice())
                     .category(menu.getCategory())
                     .build();
-            menus.add(menuResponseDto);
+            menus.add(dto);
         }
-        return menus;
+        return new MenusResponseDto(menus);
     }
 }

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
@@ -24,7 +24,7 @@ public class GetMenusUseCase {
                     .name(menu.getName())
                     .price(menu.getPrice())
                     .category(menu.getCategory())
-                    .thumnail(menu.getThumnail())
+                    .thumnail(menu.getThumnail().getThumbnail().getId())
                     .build();
             menus.add(dto);
         }

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
@@ -2,14 +2,11 @@ package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.dto.MenuResponseDto;
 import easy.gc_coffee_api.dto.MenusResponseDto;
-import easy.gc_coffee_api.entity.Menu;
 import easy.gc_coffee_api.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,17 +14,8 @@ public class GetMenusUseCase {
     private final MenuRepository menuRepository;
 
     public MenusResponseDto getMenus() {
-        List<Menu> menuList = menuRepository.findAll();
-        List<MenuResponseDto> menus = new ArrayList<>();
-        for (Menu menu : menuList) {
-            MenuResponseDto dto = MenuResponseDto.builder()
-                    .name(menu.getName())
-                    .price(menu.getPrice())
-                    .category(menu.getCategory())
-                    .thumnail(menu.getThumnail().getThumbnail().getId())
-                    .build();
-            menus.add(dto);
-        }
+        List<MenuResponseDto> menus = menuRepository.findAllByMenuResponseDto();
+
         return new MenusResponseDto(menus);
     }
 }

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
@@ -24,6 +24,7 @@ public class GetMenusUseCase {
                     .name(menu.getName())
                     .price(menu.getPrice())
                     .category(menu.getCategory())
+                    .thumnail(menu.getThumnail())
                     .build();
             menus.add(dto);
         }

--- a/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
@@ -1,6 +1,7 @@
 package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.dto.MenusResponseDto;
+import easy.gc_coffee_api.entity.File;
 import easy.gc_coffee_api.entity.Menu;
 import easy.gc_coffee_api.entity.Thumnail;
 import easy.gc_coffee_api.entity.common.Category;
@@ -34,10 +35,12 @@ class GetMenusUseCaseTests {
     @Test
     @DisplayName("메뉴 리스트 조회")
     void get_menus_test() throws Exception {
+
         // given
+        File thumbnail1 = new File("image/jpg", "/storage/78b6f135-afce-411f-8dec-01ed9969dd79.jpg");
         List<Menu> fakeMenus = Arrays.asList(
-                new Menu("Americano", 3000, Category.COFFEE_BEAN, new Thumnail(null)),
-                new Menu("Latte", 4000, Category.COFFEE_BEAN, new Thumnail(null))
+                new Menu("Americano", 3000, Category.COFFEE_BEAN, new Thumnail(new File("image/jpg", "/storage/78b6f00.jpg"))),
+                new Menu("Latte", 4000, Category.COFFEE_BEAN, new Thumnail(new File("image/jpg", "/storage/78b6f01.jpg")))
         );
         when(menuRepository.findAll()).thenReturn(fakeMenus);
         // when
@@ -47,6 +50,7 @@ class GetMenusUseCaseTests {
         assertThat(result.getMenus()).hasSize(2);
         assertThat(result.getMenus().getFirst().getName()).isEqualTo("Americano");
         assertThat(result.getMenus().get(1).getPrice()).isEqualTo(4000);
+//        assertThat(result.getMenus().get(0).getThumnail()).isEqualTo(1L);
+//        assertThat(result.getMenus().get(1).getThumnail()).isEqualTo(2L);
     }
-
 }

--- a/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
@@ -1,0 +1,52 @@
+package easy.gc_coffee_api.usecase.menu;
+
+import easy.gc_coffee_api.dto.MenusResponseDto;
+import easy.gc_coffee_api.entity.Menu;
+import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.common.Category;
+import easy.gc_coffee_api.repository.MenuRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetMenusUseCaseTests {
+    @Mock
+    private MenuRepository menuRepository;
+
+    private GetMenusUseCase getMenusUseCase;
+
+    @BeforeEach
+    void setUp() {
+        getMenusUseCase = new GetMenusUseCase(menuRepository);
+    }
+
+    @Test
+    @DisplayName("메뉴 리스트 조회")
+    void get_menus_test() throws Exception {
+        // given
+        List<Menu> fakeMenus = Arrays.asList(
+                new Menu("Americano", 3000, Category.COFFEE_BEAN, new Thumnail(null)),
+                new Menu("Latte", 4000, Category.COFFEE_BEAN, new Thumnail(null))
+        );
+        when(menuRepository.findAll()).thenReturn(fakeMenus);
+        // when
+        MenusResponseDto result = getMenusUseCase.getMenus();
+
+        // then
+        assertThat(result.getMenus()).hasSize(2);
+        assertThat(result.getMenus().getFirst().getName()).isEqualTo("Americano");
+        assertThat(result.getMenus().get(1).getPrice()).isEqualTo(4000);
+    }
+
+}

--- a/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
@@ -1,5 +1,6 @@
 package easy.gc_coffee_api.usecase.menu;
 
+import easy.gc_coffee_api.dto.MenuResponseDto;
 import easy.gc_coffee_api.dto.MenusResponseDto;
 import easy.gc_coffee_api.entity.File;
 import easy.gc_coffee_api.entity.Menu;
@@ -17,7 +18,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,23 +34,32 @@ class GetMenusUseCaseTests {
 
     @Test
     @DisplayName("메뉴 리스트 조회")
-    void get_menus_test() throws Exception {
+    void get_menus_test() {
 
         // given
-        File thumbnail1 = new File("image/jpg", "/storage/78b6f135-afce-411f-8dec-01ed9969dd79.jpg");
-        List<Menu> fakeMenus = Arrays.asList(
-                new Menu("Americano", 3000, Category.COFFEE_BEAN, new Thumnail(new File("image/jpg", "/storage/78b6f00.jpg"))),
-                new Menu("Latte", 4000, Category.COFFEE_BEAN, new Thumnail(new File("image/jpg", "/storage/78b6f01.jpg")))
+        MenuResponseDto firstDto =  new MenuResponseDto("Americano", 3000, Category.COFFEE_BEAN, "/storage/001.jpeg");
+        MenuResponseDto secondDto = new MenuResponseDto("CafeLatte", 4000, Category.COFFEE_BEAN, null);
+        List<MenuResponseDto> fakeMenus = Arrays.asList(
+                firstDto,secondDto
         );
-        when(menuRepository.findAll()).thenReturn(fakeMenus);
+
+        when(menuRepository.findAllByMenuResponseDto()).thenReturn(fakeMenus);
+
         // when
         MenusResponseDto result = getMenusUseCase.getMenus();
 
         // then
-        assertThat(result.getMenus()).hasSize(2);
-        assertThat(result.getMenus().getFirst().getName()).isEqualTo("Americano");
-        assertThat(result.getMenus().get(1).getPrice()).isEqualTo(4000);
-//        assertThat(result.getMenus().get(0).getThumnail()).isEqualTo(1L);
-//        assertThat(result.getMenus().get(1).getThumnail()).isEqualTo(2L);
+        MenuResponseDto first = result.getMenus().getFirst();
+        assertThat(first.getName()).isEqualTo(firstDto.getName());
+        assertThat(first.getPrice()).isEqualTo(firstDto.getPrice());
+        assertThat(first.getCategory()).isEqualTo(firstDto.getCategory());
+        assertThat(first.getThumbnailUrl()).isEqualTo(firstDto.getThumbnailUrl());
+
+        MenuResponseDto second = result.getMenus().get(1);
+        assertThat(second.getName()).isEqualTo(secondDto.getName());
+        assertThat(second.getPrice()).isEqualTo(secondDto.getPrice());
+        assertThat(second.getCategory()).isEqualTo(secondDto.getCategory());
+        assertThat(second.getThumbnailUrl()).isNull();
+
     }
 }


### PR DESCRIPTION
# PR 타입 (하나 이상 체크)
- [x] Feat : 새로운 기능 추가
- [ ]  Bug : 버그 발견
- [ ]  Fix : 기능 수정
- [ ]  Docs : 문서 수정
- [ ]  Style : 코드 포맷팅, 세미콜론 누락 등
- [ ]  Refactor : 리팩토링

# PR 요약
커피 메뉴 조회 기능 구현

# 반영 브랜치
feature/get-menus -> develop

# 주요 변경 사항
[src]
- controller/MenuController : GET /menus 추가
- usecase/menu/GetMenusUseCase : 커피 메뉴 조회 로직 구현
- dto/MenuResponseDto : 커피 메뉴 조회 response dto
- dto/MenusResponseDto : 커피 메뉴 조회 목록 response dto
- repository/MenuRepository : 커피 메뉴 조회 시, JPQL을 이용하여 DTO 기반 조회 구현 

[test]
- usecase/menu/GetMenusUseCaseTests : 커피 메뉴 조회 usecase 유닛테스트

# 테스트 여부

- [x] GetMenusUsecase 테스트