### PR TITLE
firx(menu): 커피 메뉴 조회 File Entity Class의 url -> key로 변경

### DIFF
--- a/src/main/java/easy/gc_coffee_api/controller/MenuController.java
+++ b/src/main/java/easy/gc_coffee_api/controller/MenuController.java
@@ -42,7 +42,7 @@ public class MenuController {
 
     @GetMapping("/menus")
     public ResponseEntity<MenusResponseDto> getMenus() {
-        MenusResponseDto responseDto = getMenusUseCase.getMenus();
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+        MenusResponseDto responseDto = getMenusUseCase.execute();
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/easy/gc_coffee_api/repository/MenuRepository.java
+++ b/src/main/java/easy/gc_coffee_api/repository/MenuRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface MenuRepository extends JpaRepository<Menu,Long> {
 
-    @Query("SELECT new easy.gc_coffee_api.dto.MenuResponseDto(m.name, m.price, m.category,case when f is null then null when f is not null then f.url end) FROM Menu m LEFT JOIN File f ON m.thumnail.fileId = f.id")
+    @Query("SELECT new easy.gc_coffee_api.dto.MenuResponseDto(m.name, m.price, m.category,case when f is null then null when f is not null then f.key end) FROM Menu m LEFT JOIN File f ON m.thumnail.fileId = f.id")
     List<MenuResponseDto> findAllByMenuResponseDto();
 }

--- a/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
+++ b/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class GetMenusUseCase {
     private final MenuRepository menuRepository;
 
-    public MenusResponseDto getMenus() {
+    public MenusResponseDto execute() {
         List<MenuResponseDto> menus = menuRepository.findAllByMenuResponseDto();
 
         return new MenusResponseDto(menus);

--- a/src/test/java/easy/gc_coffee_api/usecase/file/UploadFileUseCaseTest.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/file/UploadFileUseCaseTest.java
@@ -104,6 +104,6 @@ public class UploadFileUseCaseTest {
         verify(multipartFile, times(1)).transferTo(any(java.io.File.class));
 
         assertThat(responseDto.getId()).isEqualTo(1L);
-        assertThat(responseDto.getUrl()).isEqualTo(url);
+        assertThat(responseDto.getKey()).isEqualTo(url);
     }
 }

--- a/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
+++ b/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
@@ -2,9 +2,6 @@ package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.dto.MenuResponseDto;
 import easy.gc_coffee_api.dto.MenusResponseDto;
-import easy.gc_coffee_api.entity.File;
-import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.repository.MenuRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +43,7 @@ class GetMenusUseCaseTests {
         when(menuRepository.findAllByMenuResponseDto()).thenReturn(fakeMenus);
 
         // when
-        MenusResponseDto result = getMenusUseCase.getMenus();
+        MenusResponseDto result = getMenusUseCase.execute();
 
         // then
         MenuResponseDto first = result.getMenus().getFirst();


### PR DESCRIPTION
# PR 타입 (하나 이상 체크)
- [ ] Feat : 새로운 기능 추가
- [ ] Bug : 버그 발견
- [x] Fix : 기능 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락 등
- [ ] Refactor : 리팩토링

# PR 요약
커피 메뉴 조회 기능 구현

# 반영 브랜치
feature/get-menus -> develop

주요 변경 사항
[src]

controller/MenuController : method명을 execute로 통일
usecase/menu/GetMenusUseCase : method명을 execute로 통일
repository/MenuRepository : File 변경으로 인한 JPQL의 변경 수정
[test]

usecase/menu/GetMenusUseCaseTests : 커피 메뉴 조회 usecase 유닛테스트
usecase/file/UploadFileUseCaseTest : File 변경으로 인한, url 일치 테스트 수정 및 검증
테스트 여부

- [x] GetMenusUsecase 테스트
- [x] UploadFileUsecase 테스트