### PR TITLE
feat(menu): 커피 메뉴 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/easy/gc_coffee_api/controller/MenuController.java
+++ b/backend/src/main/java/easy/gc_coffee_api/controller/MenuController.java
@@ -1,6 +1,8 @@
 package easy.gc_coffee_api.controller;
 
 import easy.gc_coffee_api.dto.UpdateMenuRequestDto;
+import easy.gc_coffee_api.exception.menu.MenuNotFoundException;
+import easy.gc_coffee_api.usecase.menu.DeleteMenuUseCase;
 import easy.gc_coffee_api.usecase.menu.UpdateMenuUsecase;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,6 +29,7 @@ public class MenuController {
     private final CreateMenuUsecase createMenuUsecase;
     private final UpdateMenuUsecase updateMenuUsecase;
     private final GetMenusUseCase getMenusUseCase;
+    private final DeleteMenuUseCase deleteMenuUseCase;
 
     @PostMapping("/menus")
     public ResponseEntity<CreateMenuResponseDto> create(@RequestBody @Validated CreateMenuRequestDto requestDto) {
@@ -38,13 +41,13 @@ public class MenuController {
                     requestDto.getThumnailId()
             );
             return ResponseEntity.ok(new CreateMenuResponseDto(id));
-        } catch (ThumnailCreateException | EntityNotFoundException e ) {
+        } catch (ThumnailCreateException | EntityNotFoundException e) {
             throw new GCException(e.getMessage(), e, 400);
         }
     }
 
     @PutMapping("/menus/{menuId}")
-    public ResponseEntity<String> updateMenu(@PathVariable Long menuId,@RequestBody @Validated UpdateMenuRequestDto requestDto ) {
+    public ResponseEntity<String> updateMenu(@PathVariable Long menuId, @RequestBody @Validated UpdateMenuRequestDto requestDto) {
         updateMenuUsecase.execute(menuId, requestDto);
         return ResponseEntity.ok("수정 완료");
     }
@@ -55,4 +58,15 @@ public class MenuController {
         MenusResponseDto responseDto = getMenusUseCase.getMenus();
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
+
+    @DeleteMapping("/menus/{menuId}")
+    public ResponseEntity<String> deleteMenu(@PathVariable Long menuId) {
+        try {
+            deleteMenuUseCase.execute(menuId);
+            return ResponseEntity.ok("삭제 완료");
+        } catch (MenuNotFoundException e) {
+            throw new GCException(e.getMessage(), e, 400);
+        }
+    }
+
 }

--- a/backend/src/main/java/easy/gc_coffee_api/entity/Menu.java
+++ b/backend/src/main/java/easy/gc_coffee_api/entity/Menu.java
@@ -45,4 +45,17 @@ public class Menu extends BaseDateEntity {
         this.thumnail = thumbnail;
     }
 
+    public boolean hasThumbNail(){
+        if(thumnail == null || !thumnail.hasId()){
+            return false;
+        }
+        return true;
+    }
+
+    public Long getThumnailId(){
+        if(hasThumbNail()){
+            return thumnail.getFileId();
+        }
+        return null;
+    }
 }

--- a/backend/src/main/java/easy/gc_coffee_api/entity/Menu.java
+++ b/backend/src/main/java/easy/gc_coffee_api/entity/Menu.java
@@ -24,37 +24,37 @@ public class Menu extends BaseDateEntity {
     private Category category;
 
     @Embedded
-    private Thumnail thumnail;
+    private Thumbnail thumbnail;
 
-    public Menu(Long id, String name, Integer price, Category category, Thumnail thumnail) {
+    public Menu(Long id, String name, Integer price, Category category, Thumbnail thumbnail) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.category = category;
-        this.thumnail = thumnail;
+        this.thumbnail = thumbnail;
     }
 
-    public Menu(String name, Integer price, Category category, Thumnail thumbnail) {
+    public Menu(String name, Integer price, Category category, Thumbnail thumbnail) {
         this(null, name, price, category, thumbnail);
     }
 
-    public void update(String name, Integer price, Category category, Thumnail thumbnail) {
+    public void update(String name, Integer price, Category category, Thumbnail thumbnail) {
         this.name = name;
         this.price = price;
         this.category = category;
-        this.thumnail = thumbnail;
+        this.thumbnail = thumbnail;
     }
 
-    public boolean hasThumbNail(){
-        if(thumnail == null || !thumnail.hasId()){
+    public boolean hasThumbNail() {
+        if (thumbnail == null || !thumbnail.hasId()) {
             return false;
         }
         return true;
     }
 
-    public Long getThumnailId(){
-        if(hasThumbNail()){
-            return thumnail.getFileId();
+    public Long getThumbnailId() {
+        if (hasThumbNail()) {
+            return thumbnail.getFileId();
         }
         return null;
     }

--- a/backend/src/main/java/easy/gc_coffee_api/entity/Thumbnail.java
+++ b/backend/src/main/java/easy/gc_coffee_api/entity/Thumbnail.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import lombok.*;
 
 @Embeddable
@@ -14,12 +12,12 @@ import lombok.*;
 @AllArgsConstructor
 @EqualsAndHashCode
 @Getter
-public class Thumnail {
+public class Thumbnail {
 
     @Column(name = "file_id")
     private Long fileId;
 
-    public Thumnail(Long fileId,String type) throws IllegalArgumentException {
+    public Thumbnail(Long fileId, String type) throws IllegalArgumentException {
         validateType(type);
         this.fileId = fileId;
     }

--- a/backend/src/main/java/easy/gc_coffee_api/entity/Thumnail.java
+++ b/backend/src/main/java/easy/gc_coffee_api/entity/Thumnail.java
@@ -30,4 +30,8 @@ public class Thumnail {
             throw new IllegalArgumentException("Invalid type");
         }
     }
+
+    public boolean hasId(){
+        return this.fileId != null;
+    }
 }

--- a/backend/src/main/java/easy/gc_coffee_api/entity/common/BaseDateEntity.java
+++ b/backend/src/main/java/easy/gc_coffee_api/entity/common/BaseDateEntity.java
@@ -2,6 +2,8 @@ package easy.gc_coffee_api.entity.common;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -18,9 +20,12 @@ public class BaseDateEntity {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
-
-    @Setter
+    
+    @Getter
     private LocalDateTime deletedAt;
 
 
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/easy/gc_coffee_api/exception/file/FileNotFoundException.java
+++ b/backend/src/main/java/easy/gc_coffee_api/exception/file/FileNotFoundException.java
@@ -1,0 +1,9 @@
+package easy.gc_coffee_api.exception.file;
+
+import easy.gc_coffee_api.exception.GCException;
+
+public class FileNotFoundException extends GCException {
+    public FileNotFoundException(String message, Integer code) {
+        super(message, code);
+    }
+}

--- a/backend/src/main/java/easy/gc_coffee_api/repository/FileRepository.java
+++ b/backend/src/main/java/easy/gc_coffee_api/repository/FileRepository.java
@@ -3,5 +3,9 @@ package easy.gc_coffee_api.repository;
 import easy.gc_coffee_api.entity.File;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FileRepository extends JpaRepository<File,Long> {
+
+    Optional<File> findByIdAndDeletedAtIsNull(Long fileId);
 }

--- a/backend/src/main/java/easy/gc_coffee_api/repository/MenuRepository.java
+++ b/backend/src/main/java/easy/gc_coffee_api/repository/MenuRepository.java
@@ -12,7 +12,7 @@ public interface MenuRepository extends JpaRepository<Menu,Long> {
 
     @Query("SELECT new easy.gc_coffee_api.dto.MenuResponseDto(m.name, m.price, m.category," +
             " CASE WHEN f IS NULL THEN NULL WHEN f IS NOT NULL THEN f.key END)" +
-            " FROM Menu m LEFT JOIN File f ON m.thumnail.fileId = f.id" +
+            " FROM Menu m LEFT JOIN File f ON m.thumbnail.fileId = f.id" +
             " WHERE m.deletedAt IS NULL")
     List<MenuResponseDto> findAllNotDeleted();
 

--- a/backend/src/main/java/easy/gc_coffee_api/repository/MenuRepository.java
+++ b/backend/src/main/java/easy/gc_coffee_api/repository/MenuRepository.java
@@ -6,9 +6,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu,Long> {
 
-    @Query("SELECT new easy.gc_coffee_api.dto.MenuResponseDto(m.name, m.price, m.category,case when f is null then null when f is not null then f.key end) FROM Menu m LEFT JOIN File f ON m.thumnail.fileId = f.id")
-    List<MenuResponseDto> findAllByMenuResponseDto();
+    @Query("SELECT new easy.gc_coffee_api.dto.MenuResponseDto(m.name, m.price, m.category," +
+            " CASE WHEN f IS NULL THEN NULL WHEN f IS NOT NULL THEN f.key END)" +
+            " FROM Menu m LEFT JOIN File f ON m.thumnail.fileId = f.id" +
+            " WHERE m.deletedAt IS NULL")
+    List<MenuResponseDto> findAllNotDeleted();
+
+    Optional<Menu> findByIdAndDeletedAtIsNull(Long menuId);
 }

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/file/FileRemover.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/file/FileRemover.java
@@ -1,0 +1,27 @@
+package easy.gc_coffee_api.usecase.file;
+
+import easy.gc_coffee_api.repository.FileRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import easy.gc_coffee_api.entity.File;
+import easy.gc_coffee_api.exception.file.FileNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FileRemover {
+
+    private final FileRepository fileRepository;
+
+    @Transactional
+    public void remove(Long id) throws FileNotFoundException,NullPointerException {
+        File file = fileRepository
+                .findByIdAndDeletedAtIsNull(Objects.requireNonNull(id))
+                .orElseThrow(() -> new FileNotFoundException("해당 파일이 존재하지 않습니다.", 400));
+        file.delete();
+    }
+}

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecase.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecase.java
@@ -1,7 +1,7 @@
 package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.exception.ThumnailCreateException;
 import jakarta.transaction.Transactional;
@@ -17,8 +17,8 @@ public class CreateMenuUsecase{
 
     @Transactional
     public Long execute(String menuName, Category category, int price, Long fileId) throws ThumnailCreateException {
-        Thumnail thumnail = thumnailFatory.create(fileId);
-        Menu menu = menuSaver.save(menuName, category, price, thumnail);
+        Thumbnail thumbnail = thumnailFatory.create(fileId);
+        Menu menu = menuSaver.save(menuName, category, price, thumbnail);
         return menu.getId();
     }
 }

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/DeleteMenuUseCase.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/DeleteMenuUseCase.java
@@ -1,0 +1,31 @@
+package easy.gc_coffee_api.usecase.menu;
+
+import easy.gc_coffee_api.entity.Menu;
+import easy.gc_coffee_api.exception.menu.MenuNotFoundException;
+import easy.gc_coffee_api.repository.MenuRepository;
+import easy.gc_coffee_api.usecase.file.FileRemover;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteMenuUseCase {
+
+    private final MenuRepository menuRepository;
+    private final FileRemover fileRemover;
+
+    @Transactional
+    public void execute(Long menuId) throws MenuNotFoundException {
+        Menu existMenu = menuRepository
+                .findByIdAndDeletedAtIsNull(menuId)
+                .orElseThrow(() -> new MenuNotFoundException("이미 삭제된 메뉴이거나 존재하지 않는 메뉴입니다.", 400));
+        existMenu.delete();
+
+        if (existMenu.hasThumbNail()) {
+            fileRemover.remove(existMenu.getThumnailId());
+        }
+    }
+}
+
+

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/DeleteMenuUseCase.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/DeleteMenuUseCase.java
@@ -23,7 +23,7 @@ public class DeleteMenuUseCase {
         existMenu.delete();
 
         if (existMenu.hasThumbNail()) {
-            fileRemover.remove(existMenu.getThumnailId());
+            fileRemover.remove(existMenu.getThumbnailId());
         }
     }
 }

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCase.java
@@ -14,7 +14,7 @@ public class GetMenusUseCase {
     private final MenuRepository menuRepository;
 
     public MenusResponseDto getMenus() {
-        List<MenuResponseDto> menus = menuRepository.findAllByMenuResponseDto();
+        List<MenuResponseDto> menus = menuRepository.findAllNotDeleted();
 
         return new MenusResponseDto(menus);
     }

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/MenuSaver.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/MenuSaver.java
@@ -1,7 +1,7 @@
 package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,7 @@ public class MenuSaver {
 
     private final MenuRepository menuRepository;
 
-    public Menu save(String menuName, Category category, int price, Thumnail thumnail) {
-        return menuRepository.save(new Menu(menuName, price, category, thumnail));
+    public Menu save(String menuName, Category category, int price, Thumbnail thumbnail) {
+        return menuRepository.save(new Menu(menuName, price, category, thumbnail));
     }
 }

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/ThumnailFatory.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/ThumnailFatory.java
@@ -1,7 +1,7 @@
 package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.entity.File;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.exception.ThumnailCreateException;
 import easy.gc_coffee_api.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +13,13 @@ public class ThumnailFatory {
 
     private final FileRepository fileRepository;
 
-    public Thumnail create(Long thumnailId) {
+    public Thumbnail create(Long thumnailId) {
         if(thumnailId == null){
-            return new Thumnail();
+            return new Thumbnail();
         }
         try {
             File file = getFile(thumnailId);
-            return new Thumnail(file.getId(),file.getMimetype());
+            return new Thumbnail(file.getId(),file.getMimetype());
         }catch (IllegalArgumentException e){
             throw new ThumnailCreateException("image type이 아닙니다.");
         }

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/UpdateMenuUsecase.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/UpdateMenuUsecase.java
@@ -3,7 +3,7 @@ package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.dto.UpdateMenuRequestDto;
 import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.exception.menu.InvalidMenuCategoryException;
 import easy.gc_coffee_api.exception.menu.InvalidMenuNameException;
@@ -14,8 +14,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
-import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -44,13 +42,13 @@ public class UpdateMenuUsecase {
         }
 
         Category category = Category.valueOf(requestDto.getCategory().toUpperCase());
-        Thumnail thumnail = thumnailFatory.create(requestDto.getImageId());
+        Thumbnail thumbnail = thumnailFatory.create(requestDto.getImageId());
 
 
         menu.update(requestDto.getName(),
                 requestDto.getPrice(),
                 category,
-                thumnail);
+                thumbnail);
 
     }
 

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/UpdateMenuUsecase.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/UpdateMenuUsecase.java
@@ -25,25 +25,26 @@ public class UpdateMenuUsecase {
     private final ThumnailFatory thumnailFatory;
 
     @Transactional
-    public void execute(Long menuId, UpdateMenuRequestDto requestDto) throws ResponseStatusException,IllegalArgumentException {
-        Menu menu = menuRepository.findById(menuId).orElseThrow(()-> new MenuNotFoundException("메뉴가 없습니다.",404));
+    public void execute(Long menuId, UpdateMenuRequestDto requestDto) throws ResponseStatusException, IllegalArgumentException {
+        Menu menu = menuRepository
+                .findByIdAndDeletedAtIsNull(menuId)
+                .orElseThrow(() -> new MenuNotFoundException("메뉴가 없습니다.", 404));
 
-        if(requestDto.getName()==null){
-            throw new InvalidMenuNameException("이름을 입력하지 않았습니다.",400);
+        if (requestDto.getName() == null) {
+            throw new InvalidMenuNameException("이름을 입력하지 않았습니다.", 400);
         }
-        if(requestDto.getCategory()==null){
-            throw new InvalidMenuCategoryException("카테고리를 입력하지 않았습니다.",400);
+        if (requestDto.getCategory() == null) {
+            throw new InvalidMenuCategoryException("카테고리를 입력하지 않았습니다.", 400);
         }
-        if(requestDto.getPrice()==null){
-            throw new InvalidMenuPriceException("가격을 입력하지 않았습니다.",400);
+        if (requestDto.getPrice() == null) {
+            throw new InvalidMenuPriceException("가격을 입력하지 않았습니다.", 400);
         }
-        if(requestDto.getPrice()<0){
-            throw new InvalidMenuPriceException("가격은 음수일 수 없습니다.",400);
+        if (requestDto.getPrice() < 0) {
+            throw new InvalidMenuPriceException("가격은 음수일 수 없습니다.", 400);
         }
 
         Category category = Category.valueOf(requestDto.getCategory().toUpperCase());
         Thumnail thumnail = thumnailFatory.create(requestDto.getImageId());
-
 
 
         menu.update(requestDto.getName(),

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/order/OrderMenuUserCase.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/order/OrderMenuUserCase.java
@@ -55,7 +55,7 @@ public class OrderMenuUserCase {
   }
 
   private OrderMenu saveMenu(Orders savedOrder, OrderItemDto item) {
-    Menu menu = menuRepository.findById(item.getMenuId())
+    Menu menu = menuRepository.findByIdAndDeletedAtIsNull(item.getMenuId())
         .orElseThrow(() -> new EntityNotFoundException(
             "존재하지 않는 메뉴 ID: " + item.getMenuId()
         ));

--- a/backend/src/test/java/easy/gc_coffee_api/entity/MenuTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/entity/MenuTest.java
@@ -4,20 +4,19 @@ import easy.gc_coffee_api.entity.common.Category;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class MenuTest {
 
     @Test
     void 썸네일이_존재하는_메뉴() {
-        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumnail(1L, "image/jpeg"));
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumbnail(1L, "image/jpeg"));
 
         assertThat(menu.hasThumbNail()).isTrue();
     }
 
     @Test
     void 썸네일이_존재하지_않는_메뉴() {
-        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumnail());
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumbnail());
 
         assertThat(menu.hasThumbNail()).isFalse();
     }
@@ -32,23 +31,23 @@ class MenuTest {
     @Test
     void 썸네일이_존재하는_메뉴_썸네일아이디() {
         Long thumbNailId = 1L;
-        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumnail(thumbNailId, "image/jpeg"));
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumbnail(thumbNailId, "image/jpeg"));
 
-        assertThat(menu.getThumnailId()).isEqualTo(thumbNailId);
+        assertThat(menu.getThumbnailId()).isEqualTo(thumbNailId);
     }
 
     @Test
     void 썸네일이_존재하지_않는_메뉴_썸네일아이디() {
-        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumnail());
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumbnail());
 
-        assertThat(menu.getThumnailId()).isNull();
+        assertThat(menu.getThumbnailId()).isNull();
     }
 
     @Test
     void 썸네일이_null인_메뉴_썸네일아이디() {
         Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, null);
 
-        assertThat(menu.getThumnailId()).isNull();
+        assertThat(menu.getThumbnailId()).isNull();
     }
 
 }

--- a/backend/src/test/java/easy/gc_coffee_api/entity/MenuTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/entity/MenuTest.java
@@ -1,0 +1,54 @@
+package easy.gc_coffee_api.entity;
+
+import easy.gc_coffee_api.entity.common.Category;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MenuTest {
+
+    @Test
+    void 썸네일이_존재하는_메뉴() {
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumnail(1L, "image/jpeg"));
+
+        assertThat(menu.hasThumbNail()).isTrue();
+    }
+
+    @Test
+    void 썸네일이_존재하지_않는_메뉴() {
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumnail());
+
+        assertThat(menu.hasThumbNail()).isFalse();
+    }
+
+    @Test
+    void 썸네일이_null인_메뉴() {
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, null);
+
+        assertThat(menu.hasThumbNail()).isFalse();
+    }
+
+    @Test
+    void 썸네일이_존재하는_메뉴_썸네일아이디() {
+        Long thumbNailId = 1L;
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumnail(thumbNailId, "image/jpeg"));
+
+        assertThat(menu.getThumnailId()).isEqualTo(thumbNailId);
+    }
+
+    @Test
+    void 썸네일이_존재하지_않는_메뉴_썸네일아이디() {
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, new Thumnail());
+
+        assertThat(menu.getThumnailId()).isNull();
+    }
+
+    @Test
+    void 썸네일이_null인_메뉴_썸네일아이디() {
+        Menu menu = new Menu("name", 1000, Category.COFFEE_BEAN, null);
+
+        assertThat(menu.getThumnailId()).isNull();
+    }
+
+}

--- a/backend/src/test/java/easy/gc_coffee_api/entity/ThumbnailTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/entity/ThumbnailTest.java
@@ -5,16 +5,16 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
-class ThumnailTest {
+class ThumbnailTest {
 
     @Test
     void 이미지_타입아닐시_예외(){
-        assertThatThrownBy(() -> new Thumnail(1L,"text/html")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Thumbnail(1L,"text/html")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void 이미지_정상_생성(){
-        assertDoesNotThrow(() -> new Thumnail(1L,"image/png"));
+        assertDoesNotThrow(() -> new Thumbnail(1L,"image/png"));
     }
 
 }

--- a/backend/src/test/java/easy/gc_coffee_api/entity/ThumnailTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/entity/ThumnailTest.java
@@ -16,4 +16,5 @@ class ThumnailTest {
     void 이미지_정상_생성(){
         assertDoesNotThrow(() -> new Thumnail(1L,"image/png"));
     }
+
 }

--- a/backend/src/test/java/easy/gc_coffee_api/repository/MenuRepositoryTests.java
+++ b/backend/src/test/java/easy/gc_coffee_api/repository/MenuRepositoryTests.java
@@ -1,0 +1,28 @@
+package easy.gc_coffee_api.repository;
+
+import easy.gc_coffee_api.dto.MenuResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class MenuRepositoryTests {
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @Test
+    @DisplayName("JPQL 테스트")
+    void jpql_test() throws Exception {
+
+        List<MenuResponseDto> items = menuRepository.findAllNotDeleted();
+        for (MenuResponseDto item : items) {
+            System.out.println(items.size());
+            System.out.println(item.getName());
+        }
+    
+    }
+}

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/file/FileRemoverTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/file/FileRemoverTest.java
@@ -1,0 +1,52 @@
+package easy.gc_coffee_api.usecase.file;
+
+import easy.gc_coffee_api.entity.File;
+import easy.gc_coffee_api.exception.file.FileNotFoundException;
+import easy.gc_coffee_api.repository.FileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FileRemoverTest {
+
+    @Mock
+    private FileRepository fileRepository;
+    private FileRemover fileRemover;
+
+    @BeforeEach
+    public void initFileRemover(){
+        fileRemover = new FileRemover(fileRepository);
+    }
+
+    @Test
+    void 파일삭제(){
+        Long fileId = 1L;
+        File file = new File(fileId,"image/jpeg","test/url");
+        when(fileRepository.findByIdAndDeletedAtIsNull(eq(fileId))).thenReturn(Optional.of(file));
+
+        fileRemover.remove(fileId);
+
+        assertThat(file.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    void 없는_파일_삭제(){
+        Long fileId = 2L;
+        assertThatThrownBy(()->fileRemover.remove(fileId)).isInstanceOf(FileNotFoundException.class);
+    }
+
+    @Test
+    void 값에_null입력(){
+        assertThatThrownBy(()->fileRemover.remove(null)).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/file/UploadFileUseCaseTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/file/UploadFileUseCaseTest.java
@@ -104,6 +104,6 @@ public class UploadFileUseCaseTest {
         verify(multipartFile, times(1)).transferTo(any(java.io.File.class));
 
         assertThat(responseDto.getId()).isEqualTo(1L);
-        assertThat(responseDto.getUrl()).isEqualTo(url);
+        assertThat(responseDto.getKey()).isEqualTo(url);
     }
 }

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecaseTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/menu/CreateMenuUsecaseTest.java
@@ -1,7 +1,7 @@
 package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.entity.common.Category;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,9 +36,9 @@ public class CreateMenuUsecaseTest {
         Long entityId = 1L;
         Long fileId = 2L;
 
-        Thumnail thumnail = new Thumnail(2L, "image/jpeg");
-        when(thumnailFatory.create(eq(fileId))).thenReturn(thumnail);
-        when(menuSaver.save(eq(menuName),eq(category),eq(price),eq(thumnail))).thenReturn(new Menu(entityId, menuName, price, category,thumnail));
+        Thumbnail thumbnail = new Thumbnail(2L, "image/jpeg");
+        when(thumnailFatory.create(eq(fileId))).thenReturn(thumbnail);
+        when(menuSaver.save(eq(menuName),eq(category),eq(price),eq(thumbnail))).thenReturn(new Menu(entityId, menuName, price, category, thumbnail));
 
         Long id = createMenuUsecase.execute(menuName, category, price, fileId);
 

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/menu/DeleteMenuUseCaseTests.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/menu/DeleteMenuUseCaseTests.java
@@ -1,7 +1,7 @@
 package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.exception.menu.MenuNotFoundException;
 import easy.gc_coffee_api.repository.MenuRepository;
@@ -42,7 +42,7 @@ class DeleteMenuUseCaseTests {
     void deleteMenuTest() throws Exception {
         // given
         Long menuId = 2L;
-        Menu findMenu = new Menu(menuId, "Americano", 3000, Category.COFFEE_BEAN, new Thumnail(1L));
+        Menu findMenu = new Menu(menuId, "Americano", 3000, Category.COFFEE_BEAN, new Thumbnail(1L));
         when(menuRepository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(findMenu));
         // when
         // 2번 메뉴를 찾아옵니다.
@@ -69,7 +69,7 @@ class DeleteMenuUseCaseTests {
     void deleteMenuWhenFileNotExistTest() throws Exception {
         // given
         Long menuId = 2L;
-        Menu findMenu = new Menu(menuId, "Americano", 3000, Category.COFFEE_BEAN, new Thumnail(null));
+        Menu findMenu = new Menu(menuId, "Americano", 3000, Category.COFFEE_BEAN, new Thumbnail(null));
         when(menuRepository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(findMenu));
         // then
         deleteMenuUseCase.execute(menuId);

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/menu/DeleteMenuUseCaseTests.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/menu/DeleteMenuUseCaseTests.java
@@ -1,0 +1,79 @@
+package easy.gc_coffee_api.usecase.menu;
+
+import easy.gc_coffee_api.entity.Menu;
+import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.common.Category;
+import easy.gc_coffee_api.exception.menu.MenuNotFoundException;
+import easy.gc_coffee_api.repository.MenuRepository;
+import easy.gc_coffee_api.usecase.file.FileRemover;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteMenuUseCaseTests {
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    private DeleteMenuUseCase deleteMenuUseCase;
+
+    @Mock
+    private FileRemover fileRemover;
+
+    @BeforeEach
+    void setUp() {
+        deleteMenuUseCase = new DeleteMenuUseCase(menuRepository, fileRemover);
+    }
+
+    @Test
+    @DisplayName("메뉴 삭제")
+    void deleteMenuTest() throws Exception {
+        // given
+        Long menuId = 2L;
+        Menu findMenu = new Menu(menuId, "Americano", 3000, Category.COFFEE_BEAN, new Thumnail(1L));
+        when(menuRepository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(findMenu));
+        // when
+        // 2번 메뉴를 찾아옵니다.
+        // 찾아온 메뉴를 삭제합니다.
+        // 찾아온 메뉴가 가지고 있던 파일을 삭제합니다.
+        deleteMenuUseCase.execute(menuId);
+        // then
+        verify(fileRemover, times(1)).remove(eq(1L));
+        assertThat(findMenu.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("메뉴 삭제 (메뉴가 없는 경우)")
+    void deleteMenuWhenMenuNotExistTest() throws Exception {
+        // given
+        Long menuId = 1L;
+        when(menuRepository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.empty());
+        // when / then
+        assertThatThrownBy(()->deleteMenuUseCase.execute(menuId)).isInstanceOf(MenuNotFoundException.class);
+    }
+    
+    @Test
+    @DisplayName("메뉴 삭제 (파일이 없는 경우)")
+    void deleteMenuWhenFileNotExistTest() throws Exception {
+        // given
+        Long menuId = 2L;
+        Menu findMenu = new Menu(menuId, "Americano", 3000, Category.COFFEE_BEAN, new Thumnail(null));
+        when(menuRepository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(findMenu));
+        // then
+        deleteMenuUseCase.execute(menuId);
+
+        verify(fileRemover, never()).remove(any());
+    }
+}

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/menu/GetMenusUseCaseTests.java
@@ -2,9 +2,6 @@ package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.dto.MenuResponseDto;
 import easy.gc_coffee_api.dto.MenusResponseDto;
-import easy.gc_coffee_api.entity.File;
-import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.repository.MenuRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +40,7 @@ class GetMenusUseCaseTests {
                 firstDto,secondDto
         );
 
-        when(menuRepository.findAllByMenuResponseDto()).thenReturn(fakeMenus);
+        when(menuRepository.findAllNotDeleted()).thenReturn(fakeMenus);
 
         // when
         MenusResponseDto result = getMenusUseCase.getMenus();

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/menu/ThumbnailFatoryTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/menu/ThumbnailFatoryTest.java
@@ -1,7 +1,7 @@
 package easy.gc_coffee_api.usecase.menu;
 
 import easy.gc_coffee_api.entity.File;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.repository.FileRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
-class ThumnailFatoryTest {
+class ThumbnailFatoryTest {
 
     @Mock
     private FileRepository fileRepository;
@@ -26,9 +26,9 @@ class ThumnailFatoryTest {
     void null입력시_기본이미지_생성(){
         //TODO 테스트 작성
         ThumnailFatory thumnailFatory = new ThumnailFatory(fileRepository);
-        Thumnail thumnail = thumnailFatory.create(null);
+        Thumbnail thumbnail = thumnailFatory.create(null);
 
-        assertThat(thumnail.getFileId()).isNull();
+        assertThat(thumbnail.getFileId()).isNull();
     }
 
     @Test
@@ -37,8 +37,8 @@ class ThumnailFatoryTest {
         when(fileRepository.findById(eq(fileId))).thenReturn(Optional.of(new File(1L,"image/jpeg","/test/url")));
         ThumnailFatory thumnailFatory = new ThumnailFatory(fileRepository);
 
-        Thumnail thumnail = thumnailFatory.create(fileId);
+        Thumbnail thumbnail = thumnailFatory.create(fileId);
 
-        assertThat(thumnail.getFileId()).isEqualTo(fileId);
+        assertThat(thumbnail.getFileId()).isEqualTo(fileId);
     }
 }

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/menuupdate/UpdateMenuUsecaseTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/menuupdate/UpdateMenuUsecaseTest.java
@@ -49,7 +49,7 @@ public class UpdateMenuUsecaseTest {
         Long menuId = 1L;
         Menu menu = new Menu("라떼",5500, Category.COFFEE_BEAN,mock(Thumnail.class));
         Thumnail thumnail = new Thumnail(10L,"image/jpeg");
-        when(repository.findById(eq(menuId))).thenReturn(Optional.of(menu));
+        when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
         when(thumnailFatory.create(eq(10L))).thenReturn(thumnail);
 
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("아메리카노", 4000, "COFFEE_BEAN",10L);
@@ -64,7 +64,7 @@ public class UpdateMenuUsecaseTest {
     @Test
     void 메뉴_존재하지않으면_예외(){
         Long menuId=1L;
-        when(repository.findById(eq(menuId))).thenReturn(Optional.empty());
+        when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.empty());
 
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("아메리카노", 4000, "COFFEE_BEAN",10L);
         assertThatThrownBy(()->usecase.execute(menuId,request)).isInstanceOf(MenuNotFoundException.class);
@@ -77,7 +77,7 @@ public class UpdateMenuUsecaseTest {
         Thumnail thumnail = new Thumnail(10L,"image/jpeg");
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("아메리카노", 4000, null,10L);
 
-        when(repository.findById(eq(menuId))).thenReturn(Optional.of(menu));
+        when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
         assertThatThrownBy(()->usecase.execute(menuId,request)).isInstanceOf(InvalidMenuCategoryException.class);
     }
 
@@ -88,7 +88,7 @@ public class UpdateMenuUsecaseTest {
         Long menuId=1L;
         Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumnail.class));
         Thumnail thumnail = new Thumnail(10L,"image/jpeg");
-        when(repository.findById(eq(menuId))).thenReturn(Optional.of(menu));
+        when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
 
         UpdateMenuRequestDto request = new UpdateMenuRequestDto(null, 4000, "COFFEE_BEAN",10L);
         assertThatThrownBy(()->usecase.execute(menuId,request)).isInstanceOf(InvalidMenuNameException.class);
@@ -101,7 +101,7 @@ public class UpdateMenuUsecaseTest {
         Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumnail.class));
         Thumnail thumnail = new Thumnail(10L,"image/jpeg");
 
-        when(repository.findById(eq(menuId))).thenReturn(Optional.of(menu));
+        when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("커피", null, "COFFEE_BEAN",10L);
         assertThatThrownBy(()->usecase.execute(menuId,request)).isInstanceOf(InvalidMenuPriceException.class);
     }
@@ -112,7 +112,7 @@ public class UpdateMenuUsecaseTest {
         Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumnail.class));
         Thumnail thumnail = new Thumnail(10L,"image/jpeg");
 
-        when(repository.findById(eq(menuId))).thenReturn(Optional.of(menu));
+        when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("커피", -4000, "COFFEE_BEAN",10L);
         assertThatThrownBy(()->usecase.execute(menuId,request)).isInstanceOf(InvalidMenuPriceException.class);
     }
@@ -134,7 +134,7 @@ public class UpdateMenuUsecaseTest {
         Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumnail.class));
         Thumnail thumnail = new Thumnail(1L,"image/jpeg");
 
-        when(repository.findById(eq(menuId))).thenReturn(Optional.of(menu));
+        when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
         when(thumnailFatory.create(null)).thenReturn(thumnail);
 
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("커피", 4000, "COFFEE_BEAN",null);

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/menuupdate/UpdateMenuUsecaseTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/menuupdate/UpdateMenuUsecaseTest.java
@@ -2,7 +2,7 @@ package easy.gc_coffee_api.usecase.menuupdate;
 
 import easy.gc_coffee_api.dto.UpdateMenuRequestDto;
 import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.exception.menu.InvalidMenuCategoryException;
 import easy.gc_coffee_api.exception.menu.InvalidMenuNameException;
@@ -14,10 +14,8 @@ import easy.gc_coffee_api.usecase.menu.UpdateMenuUsecase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
@@ -47,10 +45,10 @@ public class UpdateMenuUsecaseTest {
     @Test
     void 메뉴_정상_업데이트() {
         Long menuId = 1L;
-        Menu menu = new Menu("라떼",5500, Category.COFFEE_BEAN,mock(Thumnail.class));
-        Thumnail thumnail = new Thumnail(10L,"image/jpeg");
+        Menu menu = new Menu("라떼",5500, Category.COFFEE_BEAN,mock(Thumbnail.class));
+        Thumbnail thumbnail = new Thumbnail(10L,"image/jpeg");
         when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
-        when(thumnailFatory.create(eq(10L))).thenReturn(thumnail);
+        when(thumnailFatory.create(eq(10L))).thenReturn(thumbnail);
 
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("아메리카노", 4000, "COFFEE_BEAN",10L);
         usecase.execute(menuId,request);
@@ -58,7 +56,7 @@ public class UpdateMenuUsecaseTest {
         assertThat(menu.getCategory()).isEqualTo(Category.COFFEE_BEAN);
         assertThat(menu.getName()).isEqualTo("아메리카노");
         assertThat(menu.getPrice()).isEqualTo(4000);
-        assertThat(menu.getThumnail()).isEqualTo(thumnail);
+        assertThat(menu.getThumbnail()).isEqualTo(thumbnail);
     }
 
     @Test
@@ -73,8 +71,8 @@ public class UpdateMenuUsecaseTest {
     @Test
     void 카테고리_null이면_예외(){
         Long menuId=1L;
-        Menu menu = new Menu("라떼",5500, Category.COFFEE_BEAN,mock(Thumnail.class));
-        Thumnail thumnail = new Thumnail(10L,"image/jpeg");
+        Menu menu = new Menu("라떼",5500, Category.COFFEE_BEAN,mock(Thumbnail.class));
+        Thumbnail thumbnail = new Thumbnail(10L,"image/jpeg");
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("아메리카노", 4000, null,10L);
 
         when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
@@ -86,8 +84,8 @@ public class UpdateMenuUsecaseTest {
     @Test
     void 이름이_null이면_예외() {
         Long menuId=1L;
-        Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumnail.class));
-        Thumnail thumnail = new Thumnail(10L,"image/jpeg");
+        Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumbnail.class));
+        Thumbnail thumbnail = new Thumbnail(10L,"image/jpeg");
         when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
 
         UpdateMenuRequestDto request = new UpdateMenuRequestDto(null, 4000, "COFFEE_BEAN",10L);
@@ -98,8 +96,8 @@ public class UpdateMenuUsecaseTest {
     @Test
     void 가격_null이면_예외(){
         Long menuId=1L;
-        Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumnail.class));
-        Thumnail thumnail = new Thumnail(10L,"image/jpeg");
+        Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumbnail.class));
+        Thumbnail thumbnail = new Thumbnail(10L,"image/jpeg");
 
         when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("커피", null, "COFFEE_BEAN",10L);
@@ -109,8 +107,8 @@ public class UpdateMenuUsecaseTest {
     @Test
     void 가격_음수면_예외(){
         Long menuId=1L;
-        Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumnail.class));
-        Thumnail thumnail = new Thumnail(10L,"image/jpeg");
+        Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumbnail.class));
+        Thumbnail thumbnail = new Thumbnail(10L,"image/jpeg");
 
         when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("커피", -4000, "COFFEE_BEAN",10L);
@@ -131,15 +129,15 @@ public class UpdateMenuUsecaseTest {
     @Test
     void 썸네일이_null일때의_기본이미지_테스트(){
         Long menuId=1L;
-        Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumnail.class));
-        Thumnail thumnail = new Thumnail(1L,"image/jpeg");
+        Menu menu = new Menu("라떼", 5500, Category.COFFEE_BEAN,mock(Thumbnail.class));
+        Thumbnail thumbnail = new Thumbnail(1L,"image/jpeg");
 
         when(repository.findByIdAndDeletedAtIsNull(eq(menuId))).thenReturn(Optional.of(menu));
-        when(thumnailFatory.create(null)).thenReturn(thumnail);
+        when(thumnailFatory.create(null)).thenReturn(thumbnail);
 
         UpdateMenuRequestDto request = new UpdateMenuRequestDto("커피", 4000, "COFFEE_BEAN",null);
         usecase.execute(menuId,request);
-        assertThat(menu.getThumnail()).isEqualTo(thumnail);
+        assertThat(menu.getThumbnail()).isEqualTo(thumbnail);
     }
 
 

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/order/OrderMenuUserCaseTest.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/order/OrderMenuUserCaseTest.java
@@ -11,7 +11,7 @@ import easy.gc_coffee_api.entity.File;
 import easy.gc_coffee_api.entity.Menu;
 import easy.gc_coffee_api.entity.OrderMenu;
 import easy.gc_coffee_api.entity.Orders;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.repository.FileRepository;
 import easy.gc_coffee_api.repository.MenuRepository;
@@ -53,8 +53,8 @@ class OrderMenuUserCaseTest {
         realFile = fileRepository.save(realFile);
 
 
-        Thumnail thumbnail1 = new Thumnail(realFile.getId(), realFile.getMimetype());
-        Thumnail thumbnail2 = new Thumnail(realFile.getId(), realFile.getMimetype());
+        Thumbnail thumbnail1 = new Thumbnail(realFile.getId(), realFile.getMimetype());
+        Thumbnail thumbnail2 = new Thumbnail(realFile.getId(), realFile.getMimetype());
 
 
         Menu menuTest1 = new Menu(null, "test1", 20_000, Category.COFFEE_BEAN, thumbnail1);

--- a/backend/src/test/java/easy/gc_coffee_api/usecase/order/OrderMenuUserCaseTest_ERROR.java
+++ b/backend/src/test/java/easy/gc_coffee_api/usecase/order/OrderMenuUserCaseTest_ERROR.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import easy.gc_coffee_api.entity.File;
 import easy.gc_coffee_api.entity.Menu;
-import easy.gc_coffee_api.entity.Thumnail;
+import easy.gc_coffee_api.entity.Thumbnail;
 import easy.gc_coffee_api.entity.common.Category;
 import easy.gc_coffee_api.repository.FileRepository;
 import easy.gc_coffee_api.repository.MenuRepository;
@@ -61,8 +61,8 @@ class OrderMenuUserCaseTest_ERROR {
     realFile = fileRepo.save(realFile);
 
 
-    Thumnail th1 = new Thumnail(realFile.getId(), realFile.getMimetype());
-    Thumnail th2 = new Thumnail(realFile.getId(), realFile.getMimetype());
+    Thumbnail th1 = new Thumbnail(realFile.getId(), realFile.getMimetype());
+    Thumbnail th2 = new Thumbnail(realFile.getId(), realFile.getMimetype());
 
 
     Menu m1 = menuRepo.save(new Menu(null, "m1", 1000, Category.COFFEE_BEAN, th1));


### PR DESCRIPTION
# PR 타입 (하나 이상 체크)
- [x] Feat : 새로운 기능 추가
- [ ] Bug : 버그 발견
- [ ] Fix : 기능 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락 등
- [ ] Refactor : 리팩토링

# PR 요약
커피 메뉴 조회 기능 구현

# 반영 브랜치
feature/delete-menu -> develop

# 주요 변경 사항
[src]

controller/MenuController : deleteMapping 구현
entity/Menu : Thumnail 검증 기능 구현
entity/Thumnail : Id 검증 기능 구현
entity/common/BaseDateEntity : `@Setter`가 아니라 delete 메서드로 구현
exception/file/FileNotFoundException : 파일 존재 여부 확인 예외 구현
repository/FileRepository : 삭제 되지 않은 파일 조회 구현
repository/MenuRepository : 삭제 되지 않은 전체 메뉴 조회 구현, 삭제 되지 않은 메뉴 조회 구현
usecase/file/FileRemover : 파일 삭제 기능 구현 및 메서드 추출
usecase/menu/DeleteMenuUseCase : 메뉴 삭제 기능 구현
usecase/menu/GetMenusUseCase : 삭제되지 않은 메뉴 조회로 수정
usecase/menu/UpdateMenuUsecase : 코드 정렬 수정
usecase/order/OrderMenuUserCase : 삭제되지 않은 메뉴를 조회하도록 수정

[test]
entity/MenuTest : 썸네일 검증 유닛테스트
repository/MenuRepositoryTests : JPQL (삭제되지 않은 메뉴 조회) 유닛테스트
usecase/menu/GetMenusUseCaseTests : 커피 메뉴 조회 usecase 유닛테스트
usecase/file/FileRemoverTest : 파일 검증 유닛테스트
usecase/file/UploadFileUseCaseTest : File 변경으로 인한, url -> key 테스트 수정 및 유닛테스트
usecase/menu/DeleteMenuUseCaseTests : 커피 메뉴 삭제 usecase 유닛테스트
usecase/menu/GetMenusUseCaseTests : 삭제되지 않은 메뉴 조회로 메서드명 변경
usecase/menuupdate/UpdateMenuUsecaseTest : 삭제되지 않은 메뉴 조회로 메서드 변경 및 유닛테스트

테스트 여부

- [x] GetMenusUsecase 테스트
- [x] UploadFileUsecase 테스트
- [x] MenuTest 테스트
- [x] MenuRepositoryTests 테스트
- [x] GetMenusUseCaseTests 테스트
- [x] FileRemoverTest 테스트
- [x] UploadFileUseCaseTest 테스트
- [x] DeleteMenuUseCaseTests 테스트
- [x] GetMenusUseCaseTests 테스트
- [x] UpdateMenuUsecaseTest 테스트 