### PR TITLE
refactor(menu): 단일 메뉴 삭제의 response 형식 수정

### DIFF
--- a/backend/src/main/java/easy/gc_coffee_api/controller/MenuController.java
+++ b/backend/src/main/java/easy/gc_coffee_api/controller/MenuController.java
@@ -52,7 +52,7 @@ public class MenuController {
     @GetMapping
     public ResponseEntity<MenusResponseDto> getMenus() {
         MenusResponseDto responseDto = getMenusUseCase.execute();
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+        return ResponseEntity.ok(responseDto);
     }
 
     @GetMapping("/{menuId}")
@@ -62,10 +62,10 @@ public class MenuController {
     }
 
     @DeleteMapping("/{menuId}")
-    public ResponseEntity<String> deleteMenu(@PathVariable Long menuId) {
+    public ResponseEntity<Void> deleteMenu(@PathVariable Long menuId) {
         try {
             deleteMenuUseCase.execute(menuId);
-            return ResponseEntity.ok("삭제 완료");
+            return ResponseEntity.noContent().build();
         } catch (MenuNotFoundException e) {
             throw new GCException(e.getMessage(), e, 400);
         }

--- a/backend/src/main/java/easy/gc_coffee_api/usecase/menu/helper/MenuReader.java
+++ b/backend/src/main/java/easy/gc_coffee_api/usecase/menu/helper/MenuReader.java
@@ -31,7 +31,6 @@ public class MenuReader {
 
     private MenuData updateFullPath(MenuData menu) {
         if(menu.hasThumbnail()){
-            updateFullPath(menu);
             menu.setFullPathUrl(fileUrlTranslator.execute(menu.getThumbnailUrl()));
         }
         return menu;


### PR DESCRIPTION
# PR 타입 (하나 이상 체크)
- [ ] Feat : 새로운 기능 추가
- [ ] Bug : 버그 발견
- [x] Fix : 기능 수정
- [ ] Docs : 문서 수정
- [x] Style : 코드 포맷팅, 세미콜론 누락 등
- [ ] Refactor : 리팩토링

# PR 요약
커피 메뉴 단일 삭제 기능의 응답 방식 수정
커피 메뉴 조회시의 updateFullPath가 무한루프가 발생하는 문제 해결

# 반영 브랜치
feature/delete-menus -> develop

# 주요 변경 사항
[src]
controller/MenuController : 단일 메뉴 삭제 시의 응답 방식 수정
usecase/menu/helper/MenuReader : updateFullPath의 무한 루프 문제 수정

[test]

테스트 여부

- [x] MenuRepositoryTests 테스트
- [x] GetMenuUseCaseTests 테스트
- [x] GetMenusUseCaseTests 테스트